### PR TITLE
Fix mermaid diagram support in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ next-env.d.ts
 
 # temp files
 *.temp
+
+.claude
+.wolf
+CLAUDE.md

--- a/source.config.ts
+++ b/source.config.ts
@@ -1,3 +1,4 @@
+import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins";
 import { metaSchema, pageSchema } from "fumadocs-core/source/schema";
 import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 
@@ -18,6 +19,7 @@ export const docs = defineDocs({
 
 export default defineConfig({
   mdxOptions: {
+    remarkPlugins: [remarkMdxMermaid],
     rehypeCodeOptions: {
       themes: {
         light: "github-light",


### PR DESCRIPTION
## Summary
- Register `remarkMdxMermaid` in `source.config.ts` so \`\`\`mermaid code fences are converted into the existing `Mermaid` MDX component (the component and `mermaid` package were already present but not wired up)
- Add `.claude`, `.wolf`, `CLAUDE.md` to `.gitignore`

## Test plan
- [x] Added a temporary `.mdx` page with a mermaid code fence and confirmed it compiles and renders via `pnpm dev`