### PR TITLE
fix sitemap URLs to use trailing slashes

### DIFF
--- a/lib/base-path.ts
+++ b/lib/base-path.ts
@@ -26,9 +26,12 @@ export function toSiteUrl(path: string) {
     process.env.NEXT_PUBLIC_BASE_URL ||
     "https://www.ultraviolet.rs/docs/cocos-ai";
   const normalizedBase = base.replace(/\/$/, "");
+  let url: string;
   if (path.startsWith(BASE_PATH)) {
-    return new URL(path, new URL(base).origin).toString();
+    url = new URL(path, new URL(base).origin).toString();
+  } else {
+    url = `${normalizedBase}${path.startsWith("/") ? path : `/${path}`}`;
   }
 
-  return `${normalizedBase}${path.startsWith("/") ? path : `/${path}`}`;
+  return url.endsWith("/") ? url : `${url}/`;
 }


### PR DESCRIPTION
Updates the shared site URL helper so generated sitemap and canonical page URLs use trailing slashes and avoid redirects.\n\nVerification:\n- pnpm lint\n- pnpm types:check\n- pnpm build\n- Confirmed generated sitemap loc entries end with trailing slashes